### PR TITLE
#106 remove duplicate value and empty value

### DIFF
--- a/store/skills.js
+++ b/store/skills.js
@@ -47,6 +47,13 @@ export const mutations = {
     state.links[index] = value
   },
   addTool(state, value) {
+    let duplicate = false
+    state.tools.forEach(v => {
+      if (v === value) {
+        duplicate = true
+      }
+    })
+    if (duplicate || value === '') return
     state.tools.push(value)
   }
 }

--- a/store/skills.js
+++ b/store/skills.js
@@ -47,13 +47,8 @@ export const mutations = {
     state.links[index] = value
   },
   addTool(state, value) {
-    let duplicate = false
-    state.tools.forEach(v => {
-      if (v === value) {
-        duplicate = true
-      }
-    })
-    if (duplicate || value === '') return
-    state.tools.push(value)
+    const tool = value.trim()
+    if (state.tools.includes(tool) || tool === '') return
+    state.tools.push(tool)
   }
 }

--- a/test/store/skills.spec.js
+++ b/test/store/skills.spec.js
@@ -129,9 +129,13 @@ describe('mutations', () => {
   })
 
   test('addTool', () => {
+    expect(testState.tools.length).toBe(0)
     addTool(testState, 'Apache')
     expect(testState.tools.length).toBe(1)
     expect(testState.tools[0]).toBe('Apache')
+    addTool(testState, 'Nginx')
+    expect(testState.tools.length).toBe(2)
+    expect(testState.tools[1]).toBe('Nginx')
   })
 
   test('addTool set duplicate value', () => {
@@ -142,8 +146,15 @@ describe('mutations', () => {
     expect(testState.tools.length).toBe(1)
     expect(testState.tools[0]).toBe('Apache')
   })
+
   test('addTool set empty value', () => {
     addTool(testState, '')
+    expect(testState.tools.length).toBe(0)
+    // 全角スペース
+    addTool(testState, '　')
+    expect(testState.tools.length).toBe(0)
+    // 半角スペース
+    addTool(testState, ' ')
     expect(testState.tools.length).toBe(0)
   })
 })

--- a/test/store/skills.spec.js
+++ b/test/store/skills.spec.js
@@ -135,6 +135,7 @@ describe('mutations', () => {
     expect(testState.tools[0]).toBe('Apache')
     addTool(testState, 'Nginx')
     expect(testState.tools.length).toBe(2)
+    expect(testState.tools[0]).toBe('Apache')
     expect(testState.tools[1]).toBe('Nginx')
   })
 

--- a/test/store/skills.spec.js
+++ b/test/store/skills.spec.js
@@ -133,4 +133,17 @@ describe('mutations', () => {
     expect(testState.tools.length).toBe(1)
     expect(testState.tools[0]).toBe('Apache')
   })
+
+  test('addTool set duplicate value', () => {
+    addTool(testState, 'Apache')
+    expect(testState.tools.length).toBe(1)
+    expect(testState.tools[0]).toBe('Apache')
+    addTool(testState, 'Apache')
+    expect(testState.tools.length).toBe(1)
+    expect(testState.tools[0]).toBe('Apache')
+  })
+  test('addTool set empty value', () => {
+    addTool(testState, '')
+    expect(testState.tools.length).toBe(0)
+  })
 })


### PR DESCRIPTION
http://localhost:3000/skills

追加したタグが重複していた時は、追加させない。
入力値が空の状態でエンターキーを押下した場合は値を追加しない。